### PR TITLE
Feature ETP-1551: Exclude constraints filter

### DIFF
--- a/resources/mapping.xml
+++ b/resources/mapping.xml
@@ -326,4 +326,9 @@ under the License.
     </element>
   </class>
 
+  <class name="org.apache.ddlutils.platform.modelexclusion.ExcludedColumn">
+    <element name="excludedColumn">
+      <attribute name="name" property="name"/>
+    </element>
+  </class>
 </betwixt-config>

--- a/resources/mapping.xml
+++ b/resources/mapping.xml
@@ -318,6 +318,12 @@ under the License.
     <element name="excludedSequence">
       <attribute name="name" property="name"/>
     </element>
-  </class>  
-  
+  </class>
+
+  <class name="org.apache.ddlutils.platform.modelexclusion.ExcludedConstraint">
+    <element name="excludedConstraint">
+      <attribute name="name" property="name"/>
+    </element>
+  </class>
+
 </betwixt-config>

--- a/src/mapping.xml
+++ b/src/mapping.xml
@@ -318,6 +318,12 @@ under the License.
     <element name="excludedSequence">
       <attribute name="name" property="name"/>
     </element>
-  </class>  
+  </class>
+
+  <class name="org.apache.ddlutils.platform.modelexclusion.ExcludedConstraint">
+    <element name="excludedConstraint">
+      <attribute name="name" property="name"/>
+    </element>
+  </class>
   
 </betwixt-config>

--- a/src/mapping.xml
+++ b/src/mapping.xml
@@ -325,5 +325,10 @@ under the License.
       <attribute name="name" property="name"/>
     </element>
   </class>
-  
+
+  <class name="org.apache.ddlutils.platform.modelexclusion.ExcludedColumns">
+    <element name="excludedColumns">
+      <attribute name="name" property="name"/>
+    </element>
+  </class>
 </betwixt-config>

--- a/src/org/apache/ddlutils/platform/ExcludeFilter.java
+++ b/src/org/apache/ddlutils/platform/ExcludeFilter.java
@@ -21,6 +21,7 @@ import java.util.Vector;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ddlutils.io.DatabaseIO;
+import org.apache.ddlutils.platform.modelexclusion.ExcludedConstraint;
 import org.apache.ddlutils.platform.modelexclusion.ExcludedFunction;
 import org.apache.ddlutils.platform.modelexclusion.ExcludedMaterializedView;
 import org.apache.ddlutils.platform.modelexclusion.ExcludedSequence;
@@ -53,6 +54,7 @@ public class ExcludeFilter implements Cloneable {
   Vector<String> excludedViews = new Vector<String>();
   List<String> excludedMaterializedViews = new ArrayList<>();
   Vector<String> excludedSequences = new Vector<String>();
+  Vector<String> excludedConstraints = new Vector<String>();
 
   private Logger log4j = Logger.getLogger(getClass());
 
@@ -83,6 +85,10 @@ public class ExcludeFilter implements Cloneable {
     for (String s : excludedSequences) {
       sb.append("  -" + s + "\n");
     }
+    sb.append("***Filtered constraings: " + "\n");
+    for (String s : excludedConstraints) {
+      sb.append("  -" + s + "\n");
+    }
     return sb.toString();
   }
 
@@ -107,6 +113,7 @@ public class ExcludeFilter implements Cloneable {
     filter.excludedTriggers.addAll(excludedTriggers);
     filter.excludedFunctions.addAll(excludedFunctions);
     filter.excludedSequences.addAll(excludedSequences);
+    filter.excludedConstraints.addAll(excludedConstraints);
 
     for (ExceptionRow row : exceptions) {
       filter.exceptions.add((ExceptionRow) row.clone());
@@ -137,6 +144,8 @@ public class ExcludeFilter implements Cloneable {
           excludedTriggers.add(((ExcludedTrigger) obj).getName());
         } else if (obj instanceof ExcludedSequence) {
           excludedSequences.add(((ExcludedSequence) obj).getName());
+        } else if (obj instanceof ExcludedConstraint) {
+          excludedConstraints.add(((ExcludedConstraint) obj).getName());
         }
       }
     } catch (Exception e) {
@@ -174,6 +183,11 @@ public class ExcludeFilter implements Cloneable {
         v.add(new ExcludedSequence(sequence));
       }
 
+      String[] constraints = getExcludedConstraints();
+      for (String constraint : constraints) {
+        v.add(new ExcludedConstraint(constraint));
+      }
+
       DatabaseIO dbIO = new DatabaseIO();
       dbIO.writeExcludedObjects(file, v);
     } catch (Exception e) {
@@ -195,6 +209,10 @@ public class ExcludeFilter implements Cloneable {
 
   public String[] getExcludedSequences() {
     return excludedSequences.toArray(new String[0]);
+  }
+
+  public String[] getExcludedConstraints() {
+    return excludedConstraints.toArray(new String[0]);
   }
 
   public String[] getExcludedFunctions() {
@@ -336,6 +354,22 @@ public class ExcludeFilter implements Cloneable {
   public boolean isInOthersExceptionsTableObject(String objectName, String tableName) {
     for (ExceptionRow row : othersexceptions) {
       if (objectName.equalsIgnoreCase(row.name1) && tableName.equalsIgnoreCase(row.name2)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public boolean isConstraintExcluded(String constraintName) {
+    if (constraintName == null || constraintName.isEmpty()) {
+      return false;
+    }
+    for (String excluded : excludedConstraints) {
+      if (excluded.endsWith("%")) {
+        String prefix = excluded.substring(0, excluded.length() -1);
+        return constraintName.startsWith(prefix);
+      }
+      if (constraintName.equalsIgnoreCase(excluded)) {
         return true;
       }
     }

--- a/src/org/apache/ddlutils/platform/ExcludeFilter.java
+++ b/src/org/apache/ddlutils/platform/ExcludeFilter.java
@@ -21,13 +21,7 @@ import java.util.Vector;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ddlutils.io.DatabaseIO;
-import org.apache.ddlutils.platform.modelexclusion.ExcludedConstraint;
-import org.apache.ddlutils.platform.modelexclusion.ExcludedFunction;
-import org.apache.ddlutils.platform.modelexclusion.ExcludedMaterializedView;
-import org.apache.ddlutils.platform.modelexclusion.ExcludedSequence;
-import org.apache.ddlutils.platform.modelexclusion.ExcludedTable;
-import org.apache.ddlutils.platform.modelexclusion.ExcludedTrigger;
-import org.apache.ddlutils.platform.modelexclusion.ExcludedView;
+import org.apache.ddlutils.platform.modelexclusion.*;
 import org.apache.log4j.Logger;
 import org.openbravo.ddlutils.util.ExceptionRow;
 
@@ -55,6 +49,7 @@ public class ExcludeFilter implements Cloneable {
   List<String> excludedMaterializedViews = new ArrayList<>();
   Vector<String> excludedSequences = new Vector<String>();
   Vector<String> excludedConstraints = new Vector<String>();
+  Vector<String> excludedColumns = new Vector<String>();
 
   private Logger log4j = Logger.getLogger(getClass());
 
@@ -85,8 +80,12 @@ public class ExcludeFilter implements Cloneable {
     for (String s : excludedSequences) {
       sb.append("  -" + s + "\n");
     }
-    sb.append("***Filtered constraings: " + "\n");
+    sb.append("***Filtered constraints: " + "\n");
     for (String s : excludedConstraints) {
+      sb.append("  -" + s + "\n");
+    }
+    sb.append("***Filtered columns: " + "\n");
+    for (String s : excludedColumns) {
       sb.append("  -" + s + "\n");
     }
     return sb.toString();
@@ -114,6 +113,7 @@ public class ExcludeFilter implements Cloneable {
     filter.excludedFunctions.addAll(excludedFunctions);
     filter.excludedSequences.addAll(excludedSequences);
     filter.excludedConstraints.addAll(excludedConstraints);
+    filter.excludedColumns.addAll(excludedColumns);
 
     for (ExceptionRow row : exceptions) {
       filter.exceptions.add((ExceptionRow) row.clone());
@@ -146,6 +146,8 @@ public class ExcludeFilter implements Cloneable {
           excludedSequences.add(((ExcludedSequence) obj).getName());
         } else if (obj instanceof ExcludedConstraint) {
           excludedConstraints.add(((ExcludedConstraint) obj).getName());
+        } else if (obj instanceof ExcludedColumn) {
+          excludedColumns.add(((ExcludedColumn) obj).getName());
         }
       }
     } catch (Exception e) {
@@ -188,6 +190,11 @@ public class ExcludeFilter implements Cloneable {
         v.add(new ExcludedConstraint(constraint));
       }
 
+      String[] columns = getExcludedColumns();
+      for (String column : columns) {
+        v.add(new ExcludedColumn(column));
+      }
+
       DatabaseIO dbIO = new DatabaseIO();
       dbIO.writeExcludedObjects(file, v);
     } catch (Exception e) {
@@ -213,6 +220,10 @@ public class ExcludeFilter implements Cloneable {
 
   public String[] getExcludedConstraints() {
     return excludedConstraints.toArray(new String[0]);
+  }
+
+  public String[] getExcludedColumns() {
+    return excludedColumns.toArray(new String[0]);
   }
 
   public String[] getExcludedFunctions() {
@@ -365,6 +376,22 @@ public class ExcludeFilter implements Cloneable {
       return false;
     }
     for (String excluded : excludedConstraints) {
+      if (excluded.endsWith("%")) {
+        String prefix = excluded.substring(0, excluded.length() -1);
+        return constraintName.startsWith(prefix);
+      }
+      if (constraintName.equalsIgnoreCase(excluded)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public boolean isColumnExcluded(String constraintName) {
+    if (constraintName == null || constraintName.isEmpty()) {
+      return false;
+    }
+    for (String excluded : excludedColumns) {
       if (excluded.endsWith("%")) {
         String prefix = excluded.substring(0, excluded.length() -1);
         return constraintName.startsWith(prefix);

--- a/src/org/apache/ddlutils/platform/ModelLoaderBase.java
+++ b/src/org/apache/ddlutils/platform/ModelLoaderBase.java
@@ -298,7 +298,6 @@ public abstract class ModelLoaderBase implements ModelLoader {
       fillRow(_stmt_pkname, new RowFiller() {
         @Override
         public void fillRow(ResultSet r) throws SQLException {
-          t.setPrimaryKey(r.getString(1).toUpperCase());
           pkNameHolder.append(r.getString(1));
         }
       });
@@ -321,16 +320,25 @@ public abstract class ModelLoaderBase implements ModelLoader {
         }
       });
     }
+    String pkNameReadFromDB = pkNameHolder.toString();
+    String pkNameUpper = pkNameHolder.toString().toUpperCase();
+    boolean pkExcluded = (pkNameUpper != null && !pkNameUpper.isEmpty() && _filter.isConstraintExcluded(pkNameUpper));
+    if (!pkExcluded) {
+      t.setPrimaryKey(pkNameUpper);
+    } else {
+      _log.debug("Excluding primary key constraint: " + pkNameUpper + " for table " + t.getName());
+    }
+
     // Columns
     t.addColumns(readColumns(tableRealName, usePrefix));
 
     // PKS
-    if (t.getPrimaryKey() != null && !t.getPrimaryKey().equals("")) {
-      _stmt_pkcolumns.setString(1, pkNameHolder.toString());
+    if (t.getPrimaryKey() != null && !t.getPrimaryKey().equals("") && !pkExcluded) {
+      _stmt_pkcolumns.setString(1, pkNameReadFromDB);
       fillList(_stmt_pkcolumns, new RowFiller() {
         @Override
         public void fillRow(ResultSet r) throws SQLException {
-          t.findColumn(r.getString(1)).setPrimaryKey(true);
+          t.findColumn(r.getString(1).toUpperCase()).setPrimaryKey(true);
         }
       });
     }
@@ -410,17 +418,23 @@ public abstract class ModelLoaderBase implements ModelLoader {
   }
 
   protected Collection readChecks(String tablename, boolean usePrefix) throws SQLException {
+    Collection checks;
     if (_prefix == null || !usePrefix) {
       _stmt_listchecks.setString(1, tablename);
-      return readList(_stmt_listchecks, new RowConstructor() {
+      checks = readList(_stmt_listchecks, new RowConstructor() {
         @Override
         public Object getRow(ResultSet r) throws SQLException {
+          String checkName = r.getString(1);
+          if (checkName != null && _filter.isConstraintExcluded(checkName.toUpperCase())) {
+            _log.debug("Excluding check constraint: " + checkName);
+            return null;
+          }
           return readCheck(r);
         }
       });
     } else if (_filter.compliesWithNamingRuleObject(tablename)) {
       _stmt_listchecks_noprefix.setString(1, tablename);
-      return readList(_stmt_listchecks_noprefix, new RowConstructor() {
+      checks = readList(_stmt_listchecks_noprefix, new RowConstructor() {
         @Override
         public Object getRow(ResultSet r) throws SQLException {
           return readCheck(r);
@@ -428,13 +442,15 @@ public abstract class ModelLoaderBase implements ModelLoader {
       });
     } else {
       _stmt_listchecks_prefix.setString(1, tablename);
-      return readList(_stmt_listchecks_prefix, new RowConstructor() {
+      checks = readList(_stmt_listchecks_prefix, new RowConstructor() {
         @Override
         public Object getRow(ResultSet r) throws SQLException {
           return readCheck(r);
         }
       });
     }
+    checks.removeIf(java.util.Objects::isNull);
+    return checks;
   }
 
   protected Check readCheck(ResultSet rs) throws SQLException {
@@ -454,9 +470,10 @@ public abstract class ModelLoaderBase implements ModelLoader {
   }
 
   protected Collection readForeignKeys(String tablename, boolean usePrefix) throws SQLException {
+    Collection fks;
     if (_prefix == null || !usePrefix) {
       _stmt_listfks.setString(1, tablename);
-      return readList(_stmt_listfks, new RowConstructor() {
+      fks = readList(_stmt_listfks, new RowConstructor() {
         @Override
         public Object getRow(ResultSet r) throws SQLException {
           return readForeignKey(r);
@@ -464,7 +481,7 @@ public abstract class ModelLoaderBase implements ModelLoader {
       });
     } else if (_filter.compliesWithNamingRuleObject(tablename)) {
       _stmt_listfks_noprefix.setString(1, tablename);
-      return readList(_stmt_listfks_noprefix, new RowConstructor() {
+      fks = readList(_stmt_listfks_noprefix, new RowConstructor() {
         @Override
         public Object getRow(ResultSet r) throws SQLException {
           return readForeignKey(r);
@@ -472,22 +489,24 @@ public abstract class ModelLoaderBase implements ModelLoader {
       });
     } else {
       _stmt_listfks_prefix.setString(1, tablename);
-      return readList(_stmt_listfks_prefix, new RowConstructor() {
+      fks = readList(_stmt_listfks_prefix, new RowConstructor() {
         @Override
         public Object getRow(ResultSet r) throws SQLException {
           return readForeignKey(r);
         }
       });
     }
-
+    fks.removeIf(java.util.Objects::isNull);
+    return fks;
   }
 
   abstract protected ForeignKey readForeignKey(ResultSet rs) throws SQLException;
 
   protected Collection readIndexes(String tablename, boolean usePrefix) throws SQLException {
+    Collection indexes;
     if (_prefix == null || !usePrefix) {
       _stmt_listindexes.setString(1, tablename);
-      return readList(_stmt_listindexes, new RowConstructor() {
+      indexes = readList(_stmt_listindexes, new RowConstructor() {
         @Override
         public Object getRow(ResultSet r) throws SQLException {
           return readIndex(r);
@@ -495,7 +514,7 @@ public abstract class ModelLoaderBase implements ModelLoader {
       });
     } else if (_filter.compliesWithNamingRuleObject(tablename)) {
       _stmt_listindexes_noprefix.setString(1, tablename);
-      return readList(_stmt_listindexes_noprefix, new RowConstructor() {
+      indexes = readList(_stmt_listindexes_noprefix, new RowConstructor() {
         @Override
         public Object getRow(ResultSet r) throws SQLException {
           return readIndex(r);
@@ -503,19 +522,30 @@ public abstract class ModelLoaderBase implements ModelLoader {
       });
     } else {
       _stmt_listindexes_prefix.setString(1, tablename);
-      return readList(_stmt_listindexes_prefix, new RowConstructor() {
+      indexes = readList(_stmt_listindexes_prefix, new RowConstructor() {
         @Override
         public Object getRow(ResultSet r) throws SQLException {
+          String indexName = r.getString(1);
+          if (indexName != null && _filter.isConstraintExcluded(indexName.toUpperCase())) {
+            _log.debug("Excluding index: " + indexName);
+            return null;
+          }
           return readIndex(r);
         }
       });
     }
-
+    indexes.removeIf(java.util.Objects::isNull);
+    return indexes;
   }
 
   protected Index readIndex(ResultSet rs) throws SQLException {
     String indexRealName = rs.getString(1);
     String indexName = indexRealName.toUpperCase();
+
+    if (indexName != null && _filter.isConstraintExcluded(indexName)) {
+      _log.debug("Excluding index: " + indexName);
+      return null;
+    }
 
     final Index inx = new Index();
 
@@ -536,17 +566,23 @@ public abstract class ModelLoaderBase implements ModelLoader {
   }
 
   protected Collection readUniques(String tablename, boolean usePrefix) throws SQLException {
+    Collection uniques;
     if (_prefix == null || !usePrefix) {
       _stmt_listuniques.setString(1, tablename);
-      return readList(_stmt_listuniques, new RowConstructor() {
+      uniques = readList(_stmt_listuniques, new RowConstructor() {
         @Override
         public Object getRow(ResultSet r) throws SQLException {
+          String uniqueName = r.getString(1);
+          if (uniqueName != null && _filter.isConstraintExcluded(uniqueName.toUpperCase())) {
+            _log.debug("Excluding unique constraint: " + uniqueName);
+            return null;
+          }
           return readUnique(r);
         }
       });
     } else if (_filter.compliesWithNamingRuleObject(tablename)) {
       _stmt_listuniques_noprefix.setString(1, tablename);
-      return readList(_stmt_listuniques_noprefix, new RowConstructor() {
+      uniques = readList(_stmt_listuniques_noprefix, new RowConstructor() {
 
         @Override
         public Object getRow(ResultSet r) throws SQLException {
@@ -555,19 +591,25 @@ public abstract class ModelLoaderBase implements ModelLoader {
       });
     } else {
       _stmt_listuniques_prefix.setString(1, tablename);
-      return readList(_stmt_listuniques_prefix, new RowConstructor() {
+      uniques = readList(_stmt_listuniques_prefix, new RowConstructor() {
         @Override
         public Object getRow(ResultSet r) throws SQLException {
           return readUnique(r);
         }
       });
     }
+    return uniques;
   }
 
   protected Unique readUnique(ResultSet rs) throws SQLException {
     // similar to readTable, see there for definition of both (regarding case)
     String constraintRealName = rs.getString(1);
     String constraintName = constraintRealName.toUpperCase();
+
+    if (constraintName != null && _filter.isConstraintExcluded(constraintName)) {
+      _log.debug("Excluding unique constraint: " + constraintName);
+      return null; // Devolver null si está excluida
+    }
 
     final Unique uni = new Unique();
 

--- a/src/org/apache/ddlutils/platform/SqlBuilder.java
+++ b/src/org/apache/ddlutils/platform/SqlBuilder.java
@@ -3473,6 +3473,9 @@ public abstract class SqlBuilder {
    */
   protected void writeExternalPrimaryKeysCreateStmt(Table table, String primaryKeyName,
       Column[] primaryKeyColumns) throws IOException {
+    if (table.getPrimaryKey() == null) {
+      return;
+    }
     if ((primaryKeyColumns.length > 0) && shouldGeneratePrimaryKeys(primaryKeyColumns)) {
       print("ALTER TABLE ");
       printlnIdentifier(getStructureObjectName(table));

--- a/src/org/apache/ddlutils/platform/modelexclusion/ExcludedColumn.java
+++ b/src/org/apache/ddlutils/platform/modelexclusion/ExcludedColumn.java
@@ -1,0 +1,35 @@
+/*
+ ************************************************************************************
+ * Copyright (C) 2010 Openbravo S.L.U.
+ * Licensed under the Apache Software License version 2.0
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to  in writing,  software  distributed
+ * under the License is distributed  on  an  "AS IS"  BASIS,  WITHOUT  WARRANTIES  OR
+ * CONDITIONS OF ANY KIND, either  express  or  implied.  See  the  License  for  the
+ * specific language governing permissions and limitations under the License.
+ ************************************************************************************
+ */
+
+package org.apache.ddlutils.platform.modelexclusion;
+
+public class ExcludedColumn {
+
+  private String name;
+
+  public ExcludedColumn() {
+    name = "";
+  }
+
+  public ExcludedColumn(String name) {
+    this.name = name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+}

--- a/src/org/apache/ddlutils/platform/modelexclusion/ExcludedConstraint.java
+++ b/src/org/apache/ddlutils/platform/modelexclusion/ExcludedConstraint.java
@@ -1,0 +1,35 @@
+/*
+ ************************************************************************************
+ * Copyright (C) 2010 Openbravo S.L.U.
+ * Licensed under the Apache Software License version 2.0
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to  in writing,  software  distributed
+ * under the License is distributed  on  an  "AS IS"  BASIS,  WITHOUT  WARRANTIES  OR
+ * CONDITIONS OF ANY KIND, either  express  or  implied.  See  the  License  for  the
+ * specific language governing permissions and limitations under the License.
+ ************************************************************************************
+ */
+
+package org.apache.ddlutils.platform.modelexclusion;
+
+public class ExcludedConstraint {
+
+  private String name;
+
+  public ExcludedConstraint() {
+    name = "";
+  }
+
+  public ExcludedConstraint(String name) {
+    this.name = name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+}

--- a/src/org/apache/ddlutils/platform/postgresql/PostgreSqlModelLoader.java
+++ b/src/org/apache/ddlutils/platform/postgresql/PostgreSqlModelLoader.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.ddlutils.model.Database;
 import org.apache.ddlutils.model.ForeignKey;
 import org.apache.ddlutils.model.Function;
@@ -156,6 +157,13 @@ public class PostgreSqlModelLoader extends ModelLoaderBase {
   protected void initMetadataSentences() throws SQLException {
     String sql;
     boolean firstExpressionInWhereClause = false;
+    String sql0 =
+        "SELECT UPPER(TABLENAME) FROM PG_TABLES " +
+            "JOIN PG_CLASS ON PG_CLASS.OID = PG_TABLES.oid AND PG_CLASS.RELISPARTITION = false " +
+            " WHERE SCHEMANAME = CURRENT_SCHEMA() "
+            + _filter.getExcludeFilterWhereClause("TABLENAME", _filter.getExcludedTables(),
+            firstExpressionInWhereClause)
+            + " ORDER BY UPPER(TABLENAME)";
     _stmt_listtables = _connection.prepareStatement(
         "SELECT UPPER(TABLENAME) FROM PG_TABLES WHERE SCHEMANAME = CURRENT_SCHEMA() "
             + _filter.getExcludeFilterWhereClause("TABLENAME", _filter.getExcludedTables(),
@@ -240,7 +248,16 @@ public class PostgreSqlModelLoader extends ModelLoaderBase {
 
     sql = "SELECT pg_constraint.conname AS constraint_name, upper(fk_table.relname::text), upper(pg_constraint.confdeltype::text), 'A'"
         + " FROM pg_constraint JOIN pg_class ON pg_class.oid = pg_constraint.conrelid LEFT JOIN pg_class fk_table ON fk_table.oid = pg_constraint.confrelid"
-        + " WHERE pg_constraint.contype = 'f' and pg_class.relname = ?";
+        + " WHERE pg_constraint.contype = 'f' and fk_table.relispartition = false and pg_class.relname = ? "
+        + _filter.getExcludeFilterWhereClause("CONNAME", _filter.getExcludedConstraints(),
+        false);
+    String wildcardFilter = "";
+    for (String excludedConstraint : _filter.getExcludedConstraints()) {
+      if(excludedConstraint.endsWith("%")) {
+        wildcardFilter += " AND NOT upper(conname) like '" + excludedConstraint + "' ";
+      }
+    }
+    sql += wildcardFilter;
     _stmt_listfks = _connection
         .prepareStatement(sql + " ORDER BY upper(pg_constraint.conname::text)");
     _stmt_listfks_noprefix = _connection
@@ -357,7 +374,7 @@ public class PostgreSqlModelLoader extends ModelLoaderBase {
         + "WHEN 28 THEN 'INSERT, UPDATE, DELETE' " + "WHEN 24 THEN 'UPDATE, DELETE' "
         + "WHEN 12 THEN 'INSERT, DELETE' " + "END AS trigger_event, " + "p.prosrc AS function_code "
         + "FROM pg_trigger trg, pg_class tbl, pg_proc p "
-        + "WHERE trg.tgrelid = tbl.oid AND trg.tgfoid = p.oid AND tbl.relname !~ '^pg_' AND trg.tgname !~ '^RI'"
+        + "WHERE trg.tgrelid = tbl.oid AND trg.tgfoid = p.oid AND tbl.relispartition = false AND tbl.relname !~ '^pg_' AND trg.tgname !~ '^RI'"
         + " AND upper(trg.tgname) NOT LIKE 'AU\\\\_%'" + _filter.getExcludeFilterWhereClause(
             "trg.tgname", _filter.getExcludedTriggers(), firstExpressionInWhereClause);
 
@@ -1227,6 +1244,10 @@ public class PostgreSqlModelLoader extends ModelLoaderBase {
     String fkRealName = rs.getString(1);
     String fkName = fkRealName.toUpperCase();
 
+    if (fkName != null && _filter.isConstraintExcluded(fkName)) {
+      _log.debug("Excluding foreign key constraint: " + fkName);
+      return null;
+    }
     final ForeignKey fk = new ForeignKey();
 
     fk.setName(fkName);

--- a/src/org/apache/ddlutils/platform/postgresql/PostgreSqlPlatform.java
+++ b/src/org/apache/ddlutils/platform/postgresql/PostgreSqlPlatform.java
@@ -371,12 +371,16 @@ public class PostgreSqlPlatform extends PlatformImplBase {
 
   @Override
   protected String getQueryToBuildTriggerDisablementQuery() {
-    return "SELECT 'ALTER TABLE'|| ' ' || relname || ' ' || 'DISABLE TRIGGER USER;' SQL_STR from (select distinct relname from pg_trigger trg left join pg_class tbl on trg.tgrelid = tbl.oid where tgisinternal = false order by relname) a";
+    return "SELECT 'ALTER TABLE'|| ' ' || nspname || '.' || relname || ' ' || 'DISABLE TRIGGER USER;' SQL_STR from (" +
+        "select distinct ns.nspname, relname from pg_trigger trg left join pg_class tbl on trg.tgrelid = tbl.oid JOIN pg_namespace AS ns  ON tbl.relnamespace = ns.oid where tgisinternal = false order by ns.nspname, relname" +
+        ") a";
   }
 
   @Override
   protected String getQueryToBuildTriggerEnablementQuery() {
-    return "SELECT 'ALTER TABLE'|| ' ' || relname || ' ' || 'ENABLE TRIGGER USER;' SQL_STR from (select distinct relname from pg_trigger trg left join pg_class tbl on trg.tgrelid = tbl.oid where tgisinternal = false order by relname) a";
+    return "SELECT 'ALTER TABLE'|| ' ' || nspname || '.' || relname || ' ' || 'ENABLE TRIGGER USER;' SQL_STR from (" +
+        "select distinct ns.nspname, relname from pg_trigger trg left join pg_class tbl on trg.tgrelid = tbl.oid JOIN pg_namespace AS ns  ON tbl.relnamespace = ns.oid where tgisinternal = false order by ns.nspname, relname" +
+        ") a";
   }
 
   @Override

--- a/src/org/openbravo/ddlutils/process/DBUpdater.java
+++ b/src/org/openbravo/ddlutils/process/DBUpdater.java
@@ -28,10 +28,7 @@ import org.apache.ddlutils.alteration.Change;
 import org.apache.ddlutils.alteration.DataComparator;
 import org.apache.ddlutils.alteration.RemoveRowChange;
 import org.apache.ddlutils.io.DatabaseIO;
-import org.apache.ddlutils.model.Column;
-import org.apache.ddlutils.model.Database;
-import org.apache.ddlutils.model.DatabaseData;
-import org.apache.ddlutils.model.Table;
+import org.apache.ddlutils.model.*;
 import org.apache.ddlutils.platform.ExcludeFilter;
 import org.apache.log4j.Logger;
 import org.apache.tools.ant.BuildException;
@@ -121,6 +118,17 @@ public class DBUpdater {
       platform.deleteInvalidConstraintRows(db, ad, adTablesWithRemovedRecords, !failonerror);
 
       final Database oldModel = (Database) originaldb.clone();
+      for (Table table : db.getTables()) {
+        if (excludeFilter.isConstraintExcluded(table.getPrimaryKey())) {
+          System.out.println("Target PK " + table.getPrimaryKey());
+          table.setPrimaryKey(null);
+        }
+        for (ForeignKey foreignKey : table.getForeignKeys()) {
+          if(excludeFilter.isConstraintExcluded(foreignKey.getName())) {
+            table.removeForeignKey(foreignKey);
+          }
+        }
+      }
       @SuppressWarnings("rawtypes")
       List changes = platform.alterTablesRecreatePKs(oldModel, db, !failonerror);
 
@@ -232,6 +240,18 @@ public class DBUpdater {
       }
       log.debug("Found " + fileArray.length + " module files ");
       db = DatabaseUtils.readDatabaseWithoutConfigScript(fileArray);
+
+      // Apply exclude filter for constraints
+      for (Table table : db.getTables()) {
+        if (excludeFilter.isConstraintExcluded(table.getPrimaryKey())) {
+          table.setPrimaryKey(null);
+        }
+        for (ForeignKey foreignKey : table.getForeignKeys()) {
+          if (excludeFilter.isConstraintExcluded(foreignKey.getName())) {
+            table.removeForeignKey(foreignKey);
+          }
+        }
+      }
     }
     db.checkDataTypes();
     return db;
@@ -243,7 +263,7 @@ public class DBUpdater {
       // This updates the modules dirs to use
       ModulesUtil.checkCoreInSources(ModulesUtil.coreInSources());
 
-      String auxBasedir = basedir + "../";
+      String auxBasedir = basedir + "/../";
 
       //Core in JAR
       if (!ModulesUtil.coreInSources) {

--- a/src/org/openbravo/ddlutils/task/ExportDatabase.java
+++ b/src/org/openbravo/ddlutils/task/ExportDatabase.java
@@ -426,24 +426,44 @@ public class ExportDatabase extends BaseDalInitializingTask {
     getLog().info("  Validating Module...");
     final Module moduleToValidate = OBDal.getInstance().get(Module.class, moduleId);
     boolean validateAD = shouldExportAD();
-    List<ModuleDBPrefix> dbPrefixes = moduleToValidate.getModuleDBPrefixList();
-    String dbPrefix = dbPrefixes.get(0).getName();
     List<String> partitionedTables = getPartitionedTables(ds);
-    getLog().info("    Partitioned tables: " + partitionedTables.toString());
-    DatabaseData databaseData = new DatabaseData(dbI);
+    getLog().info("    Partitioned tables: " + partitionedTables);
+    StringBuilder partitionedTablesToRemove = new StringBuilder();
 
     for (Table table : dbI.getTables()) {
       if (partitionedTables.contains(table.getName().toLowerCase())) {
-        throw new OBException("Module contains partitioned table: " + table.getName() + ". Please remove partitioning and try again.");
+        if (!partitionedTablesToRemove.isEmpty()) {
+          partitionedTablesToRemove.append(", ");
+        }
+        partitionedTablesToRemove.append(table.getName().toLowerCase());
       }
     }
+
+    if (!partitionedTablesToRemove.isEmpty()) {
+      String unpartitionMessage = getUnpartitionMessage(partitionedTablesToRemove);
+      throw new OBException(unpartitionMessage);
+    }
+
     final SystemValidationResult result = SystemService.getInstance()
         .validateDatabase(moduleToValidate, dbI, validateAD);
     SystemService.getInstance().logValidationResult(log, result);
-    if (result.getErrors().size() > 0) {
+    if (!result.getErrors().isEmpty()) {
       throw new OBException(
           "Module validation failed, see the above list of errors for more information");
     }
+  }
+
+  private static String getUnpartitionMessage(StringBuilder partitionedTablesToRemove) {
+    String tables = partitionedTablesToRemove.toString();
+    String tableWord = partitionedTablesToRemove.length() > 1 ? "tables" : "table";
+    return "\n" +
+        "=============================================================\n" +
+        "  ERROR: The module contains partitioned " + tableWord + ": " + tables + "\n" +
+        "=============================================================\n" +
+        "Please unpartition the " + tableWord + " and try again.\n" +
+        "HINT: You can unpartition tables by running:\n" +
+        "  python3 modules/com.etendoerp.db.extended/tool/unpartition.py \"" + tables + "\"\n" +
+        "=============================================================\n";
   }
 
   private void validateAPIForModel(Platform platform, Database dbDB, Database dbXml,

--- a/src/org/openbravo/ddlutils/task/ExportDatabase.java
+++ b/src/org/openbravo/ddlutils/task/ExportDatabase.java
@@ -15,6 +15,10 @@ package org.openbravo.ddlutils.task;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -33,6 +37,7 @@ import org.apache.ddlutils.io.DatabaseIO;
 import org.apache.ddlutils.model.Database;
 import org.apache.ddlutils.model.DatabaseData;
 import org.apache.ddlutils.model.StructureObject;
+import org.apache.ddlutils.model.Table;
 import org.apache.ddlutils.platform.ExcludeFilter;
 import org.apache.tools.ant.BuildException;
 import org.openbravo.base.exception.OBException;
@@ -44,6 +49,7 @@ import org.openbravo.ddlutils.util.OBDatasetTable;
 import org.openbravo.ddlutils.util.ValidateAPIData;
 import org.openbravo.ddlutils.util.ValidateAPIModel;
 import org.openbravo.model.ad.module.Module;
+import org.openbravo.model.ad.module.ModuleDBPrefix;
 import org.openbravo.service.system.SystemService;
 import org.openbravo.service.system.SystemValidationResult;
 
@@ -222,7 +228,7 @@ public class ExportDatabase extends BaseDalInitializingTask {
         }
 
         if (validateModel) {
-          validateDatabaseForModule(util.getActiveModule(i).idMod, dbI);
+          validateDatabaseForModule(util.getActiveModule(i).idMod, dbI, ds);
         }
 
         getLog().debug("  Path: " + path);
@@ -380,6 +386,21 @@ public class ExportDatabase extends BaseDalInitializingTask {
     }
   }
 
+  private List<String> getPartitionedTables(BasicDataSource ds) {
+    List<String> partitionedTables = new ArrayList<>();
+    String sql = "SELECT relname FROM pg_class WHERE relkind = 'p'";
+    try (Connection conn = ds.getConnection();
+         PreparedStatement ps = conn.prepareStatement(sql);
+         ResultSet rs = ps.executeQuery()) {
+      while (rs.next()) {
+        partitionedTables.add(rs.getString("relname").toLowerCase());
+      }
+    } catch (SQLException e) {
+      throw new OBException("Error checking partitioned tables: " + e.getMessage(), e);
+    }
+    return partitionedTables;
+  }
+
   protected boolean shouldExportAD() {
     return true;
   }
@@ -401,10 +422,21 @@ public class ExportDatabase extends BaseDalInitializingTask {
     return adDatabase;
   }
 
-  private void validateDatabaseForModule(String moduleId, Database dbI) {
+  private void validateDatabaseForModule(String moduleId, Database dbI, BasicDataSource ds) {
     getLog().info("  Validating Module...");
     final Module moduleToValidate = OBDal.getInstance().get(Module.class, moduleId);
     boolean validateAD = shouldExportAD();
+    List<ModuleDBPrefix> dbPrefixes = moduleToValidate.getModuleDBPrefixList();
+    String dbPrefix = dbPrefixes.get(0).getName();
+    List<String> partitionedTables = getPartitionedTables(ds);
+    getLog().info("    Partitioned tables: " + partitionedTables.toString());
+    DatabaseData databaseData = new DatabaseData(dbI);
+
+    for (Table table : dbI.getTables()) {
+      if (partitionedTables.contains(table.getName().toLowerCase())) {
+        throw new OBException("Module contains partitioned table: " + table.getName() + ". Please remove partitioning and try again.");
+      }
+    }
     final SystemValidationResult result = SystemService.getInstance()
         .validateDatabase(moduleToValidate, dbI, validateAD);
     SystemService.getInstance().logValidationResult(log, result);

--- a/src/org/openbravo/ddlutils/task/ImportSampledata.java
+++ b/src/org/openbravo/ddlutils/task/ImportSampledata.java
@@ -21,7 +21,9 @@ import org.apache.ddlutils.io.DataReader;
 import org.apache.ddlutils.io.DataToArraySink;
 import org.apache.ddlutils.io.DatabaseDataIO;
 import org.apache.ddlutils.model.Database;
+import org.apache.ddlutils.model.ForeignKey;
 import org.apache.ddlutils.model.Table;
+import org.apache.ddlutils.platform.ExcludeFilter;
 import org.apache.ddlutils.platform.postgresql.PostgreSqlDatabaseDataIO;
 import org.apache.log4j.Logger;
 import org.apache.tools.ant.BuildException;
@@ -73,6 +75,9 @@ public class ImportSampledata extends BaseDatabaseTask {
     getLog().info("Database connection: " + getUrl() + ". User: " + getUser());
     final BasicDataSource ds = DBSMOBUtil.getDataSource(getDriver(), getUrl(), getUser(),
       getPassword());
+
+    ExcludeFilter excludeFilter = DBSMOBUtil.getInstance()
+        .getExcludeFilter(new File( basedir));
 
     final Platform platform = PlatformFactory.createNewPlatformInstance(ds);
     // default value defined for a column should be used on missing data
@@ -231,6 +236,14 @@ public class ImportSampledata extends BaseDatabaseTask {
         log.info("   Enabling triggers");
         platform.enableAllTriggers(con, db, false);
         log.info("   Enabling foreign keys");
+        // disable excluded foreign keys
+        for (Table table : db.getTables()) {
+          for (ForeignKey foreignKey : table.getForeignKeys()) {
+            if(excludeFilter.isConstraintExcluded(foreignKey.getName())) {
+              table.removeForeignKey(foreignKey);
+            }
+          }
+        }
         platform.enableAllFK(con, db, false);
       } finally {
         if (con != null) {


### PR DESCRIPTION
This pull request introduces functionality to exclude specific database constraints, such as primary keys, foreign keys, unique constraints, and indexes, during metadata processing. The changes include updates to the filtering logic, new data structures, and enhancements to existing methods to support constraint exclusions.

### Constraint Exclusion Enhancements:

* Added a new class, `ExcludedConstraint`, to represent constraints that should be excluded from processing. (`src/org/apache/ddlutils/platform/modelexclusion/ExcludedConstraint.java`)
* Updated `ExcludeFilter` to handle excluded constraints with new methods (`getExcludedConstraints`, `isConstraintExcluded`) and extended the `fillFromFile` and `exportToFile` methods to include constraints. (`src/org/apache/ddlutils/platform/ExcludeFilter.java`) [[1]](diffhunk://#diff-02178d6ba32c4989d4aa217e1ff670db09e88582bb8b19f23c9ee28b580848d4R24) [[2]](diffhunk://#diff-02178d6ba32c4989d4aa217e1ff670db09e88582bb8b19f23c9ee28b580848d4R57) [[3]](diffhunk://#diff-02178d6ba32c4989d4aa217e1ff670db09e88582bb8b19f23c9ee28b580848d4R88-R91) [[4]](diffhunk://#diff-02178d6ba32c4989d4aa217e1ff670db09e88582bb8b19f23c9ee28b580848d4R116) [[5]](diffhunk://#diff-02178d6ba32c4989d4aa217e1ff670db09e88582bb8b19f23c9ee28b580848d4R147-R148) [[6]](diffhunk://#diff-02178d6ba32c4989d4aa217e1ff670db09e88582bb8b19f23c9ee28b580848d4R186-R190) [[7]](diffhunk://#diff-02178d6ba32c4989d4aa217e1ff670db09e88582bb8b19f23c9ee28b580848d4R214-R217) [[8]](diffhunk://#diff-02178d6ba32c4989d4aa217e1ff670db09e88582bb8b19f23c9ee28b580848d4R363-R378)

### Metadata Processing Updates:

* Enhanced `ModelLoaderBase` to respect excluded constraints when processing primary keys, unique constraints, foreign keys, and indexes. Added filtering logic to skip excluded constraints and log debug messages for exclusions. (`src/org/apache/ddlutils/platform/ModelLoaderBase.java`) [[1]](diffhunk://#diff-21a6e84bed13ad0687f859f7368f37fe39fc9aee2e136b7eac333511771c18ecR323-R341) [[2]](diffhunk://#diff-21a6e84bed13ad0687f859f7368f37fe39fc9aee2e136b7eac333511771c18ecR421-R453) [[3]](diffhunk://#diff-21a6e84bed13ad0687f859f7368f37fe39fc9aee2e136b7eac333511771c18ecR473-R549) [[4]](diffhunk://#diff-21a6e84bed13ad0687f859f7368f37fe39fc9aee2e136b7eac333511771c18ecR569-R585) [[5]](diffhunk://#diff-21a6e84bed13ad0687f859f7368f37fe39fc9aee2e136b7eac333511771c18ecL558-R613)
* Updated PostgreSQL-specific `PostgreSqlModelLoader` to apply constraint exclusions in SQL queries for metadata retrieval, including support for wildcard exclusions. (`src/org/apache/ddlutils/platform/postgresql/PostgreSqlModelLoader.java`) [[1]](diffhunk://#diff-c7b0634c77d6135b220c495a229919ef5033f62ca978798fd470bc8f4e956ce7R160-R166) [[2]](diffhunk://#diff-c7b0634c77d6135b220c495a229919ef5033f62ca978798fd470bc8f4e956ce7L243-R260) [[3]](diffhunk://#diff-c7b0634c77d6135b220c495a229919ef5033f62ca978798fd470bc8f4e956ce7L360-R377) [[4]](diffhunk://#diff-c7b0634c77d6135b220c495a229919ef5033f62ca978798fd470bc8f4e956ce7R1247-R1250)

### Bug Fixes and Code Refinements:

* Fixed a bug in `SqlBuilder` to avoid generating primary key statements when the primary key is excluded. (`src/org/apache/ddlutils/platform/SqlBuilder.java`)
* Refactored metadata processing methods to remove null entries from collections after filtering excluded constraints. (`src/org/apache/ddlutils/platform/ModelLoaderBase.java`) [[1]](diffhunk://#diff-21a6e84bed13ad0687f859f7368f37fe39fc9aee2e136b7eac333511771c18ecR421-R453) [[2]](diffhunk://#diff-21a6e84bed13ad0687f859f7368f37fe39fc9aee2e136b7eac333511771c18ecR473-R549) [[3]](diffhunk://#diff-21a6e84bed13ad0687f859f7368f37fe39fc9aee2e136b7eac333511771c18ecR569-R585)

### Configuration Updates:

* Added mappings for the new `ExcludedConstraint` class in `mapping.xml` files to support XML-based configuration. (`resources/mapping.xml`, `src/mapping.xml`) [[1]](diffhunk://#diff-775f2e67d0886635e2524f9aaffe923dcf34f80fe0b9b6a4a00387586a5ea9d4R323-R328) [[2]](diffhunk://#diff-5b88316495ee2598b829bc51efd1d506ea7364a0a34d1283ee25a1b6734099e2R323-R328)