### PR TITLE
Feature ETP-1917: replace OBException with local DBSMException in DBSMOBUtil

### DIFF
--- a/src/org/openbravo/ddlutils/util/DBSMException.java
+++ b/src/org/openbravo/ddlutils/util/DBSMException.java
@@ -1,0 +1,49 @@
+/*
+ ************************************************************************************
+ * Copyright (C) 2001-2020 Openbravo S.L.U.
+ * Licensed under the Apache Software License version 2.0
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to  in writing,  software  distributed
+ * under the License is distributed  on  an  "AS IS"  BASIS,  WITHOUT  WARRANTIES  OR
+ * CONDITIONS OF ANY KIND, either  express  or  implied.  See  the  License  for  the
+ * specific language governing permissions and limitations under the License.
+ ************************************************************************************
+ */
+
+package org.openbravo.ddlutils.util;
+
+/**
+ * Exception specific to errors related to DB Source Manager (DBSM).
+ * <p>
+ * This exception extends {@link RuntimeException}, making it an unchecked exception
+ * that does not need to be declared in method signatures.
+ * </p>
+ *
+ * <p>
+ * It is used to wrap errors that occur during DB Source Manager operations,
+ * such as schema generation, validation, or script execution.
+ * </p>
+ */
+public class DBSMException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Constructs a new {@code DBSMException} with the specified detail message.
+   *
+   * @param message the detail message describing the error
+   */
+  public DBSMException(String message) {
+    super(message);
+  }
+
+  /**
+   * Constructs a new {@code DBSMException} with the specified detail message and cause.
+   *
+   * @param message the detail message describing the error
+   * @param cause the original cause of the exception
+   */
+  public DBSMException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/org/openbravo/ddlutils/util/DBSMOBUtil.java
+++ b/src/org/openbravo/ddlutils/util/DBSMOBUtil.java
@@ -56,7 +56,7 @@ import org.apache.ddlutils.platform.ModelBasedResultSetIterator;
 import org.apache.log4j.Logger;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
-import org.openbravo.base.exception.OBException;
+
 import org.openbravo.ddlutils.task.DatabaseUtils;
 
 public class DBSMOBUtil {
@@ -648,17 +648,17 @@ public class DBSMOBUtil {
             File sslRootCertFile = new File(sslRootCert);
             if (sslRootCertFile.exists() && sslRootCertFile.isFile()) {
               if (!sslRootCertFile.canRead()) {
-                throw new OBException("SSL root certificate file is not readable: " + sslRootCertFile.getAbsolutePath());
+                throw new DBSMException("SSL root certificate file is not readable: " + sslRootCertFile.getAbsolutePath());
               }
               connProps.setProperty("sslrootcert", sslRootCertFile.getAbsolutePath());
             } else {
-              throw new OBException("SSL root certificate file not found: " + sslRootCert);
+              throw new DBSMException("SSL root certificate file not found: " + sslRootCert);
             }
           } else {
             // If the mode requires verification, the certificate is mandatory.
             if (StringUtils.equals("verify-full", (connProps.getProperty(SSLMODE))) ||
                 StringUtils.equals("verify-ca", (connProps.getProperty(SSLMODE)))) {
-              throw new OBException("bbdd.sslrootcert property is required when bbdd.sslfactory is not set and sslmode is " + connProps.getProperty(
+              throw new DBSMException("bbdd.sslrootcert property is required when bbdd.sslfactory is not set and sslmode is " + connProps.getProperty(
                   SSLMODE));
             }
         }
@@ -677,7 +677,7 @@ public class DBSMOBUtil {
       errorMsg.append(", sslfactory=").append(sslFactory != null ? sslFactory : "not set");
       errorMsg.append(", sslrootcert=").append(sslRootCert != null ? sslRootCert : "not set");
       getLog().error("Error while retrieving an unpooled connection: " + errorMsg.toString(), e);
-      throw new OBException(errorMsg.toString(), e);
+      throw new DBSMException(errorMsg.toString(), e);
   }
   return connection;
 }


### PR DESCRIPTION
This pull request introduces a new custom exception class, `DBSMException`, and updates the database utility code to use this exception instead of the more generic `OBException` when handling SSL certificate-related errors and connection failures. This change improves error specificity and clarity in the DDLUtils utility layer.

**Exception handling improvements:**

* Added a new custom runtime exception class, `DBSMException`, in `DBSMException.java` to provide more specific error reporting for database schema management operations.
* Updated the `DBSMOBUtil` class to throw `DBSMException` instead of `OBException` for SSL root certificate validation errors and unpooled connection failures, resulting in clearer and more consistent error handling in these scenarios. [[1]](diffhunk://#diff-26b6415f0532f94590a80005f79d85a5bb71dac6f28936c12e529bcca5a88664L651-R661) [[2]](diffhunk://#diff-26b6415f0532f94590a80005f79d85a5bb71dac6f28936c12e529bcca5a88664L680-R680)

**Code cleanup:**

* Removed the unused import of `OBException` from `DBSMOBUtil.java` since it is no longer referenced in the file.